### PR TITLE
fix: use non-primitive on v-for key

### DIFF
--- a/src/components/vue-email-autocomplete.vue
+++ b/src/components/vue-email-autocomplete.vue
@@ -4,7 +4,7 @@
       <div class="auto-complete-container" :style='mapCSS("container")'>
       <div class="auto-complete-overlay" v-if='overlayVisible && matches.length > 0' :style='mapCSS("overlay")'>
         <ul>
-          <li v-for='(match, index) in matches' :key='index' @click='completeInput(inputVal+match.completion)' :class='index === selectedMatch ? "selected" : ""' :style='mapCSS("text.suggestion")'><span v-html='inputVal'></span><span class="completion" v-html='match.completion' :style='mapCSS("text.highlight")'></span></li>
+          <li v-for='(match, index) in matches' :key='`${match}-${index}`' @click='completeInput(inputVal+match.completion)' :class='index === selectedMatch ? "selected" : ""' :style='mapCSS("text.suggestion")'><span v-html='inputVal'></span><span class="completion" v-html='match.completion' :style='mapCSS("text.highlight")'></span></li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
FIX vue issue for:
[Vue warn]: Avoid using non-primitive value as key, use string/number value instead.
